### PR TITLE
Add CCNotFoundException 

### DIFF
--- a/src/main/java/seedu/address/logic/commands/SelectClassCommand.java
+++ b/src/main/java/seedu/address/logic/commands/SelectClassCommand.java
@@ -7,6 +7,7 @@ import javafx.collections.ObservableList;
 import seedu.address.logic.Messages;
 import seedu.address.model.Model;
 import seedu.address.model.person.Classes;
+import seedu.address.model.person.exceptions.CCNotFoundException;
 
 /**
  * Selects the Class to be viewed or modified currently.

--- a/src/main/java/seedu/address/model/person/UniqueClassList.java
+++ b/src/main/java/seedu/address/model/person/UniqueClassList.java
@@ -9,6 +9,7 @@ import java.util.List;
 
 import javafx.collections.FXCollections;
 import javafx.collections.ObservableList;
+import seedu.address.model.person.exceptions.CCNotFoundException;
 import seedu.address.model.person.exceptions.DuplicateClassException;
 
 /**
@@ -60,9 +61,9 @@ public class UniqueClassList implements Iterable<Classes> {
         requireAllNonNull(target, editedClass);
 
         int index = internalList.indexOf(target);
-//        if (index == -1) {
-//            throw new CcNotFoundException();
-//        }
+        if (index == -1) {
+            throw new CCNotFoundException();
+        }
         if (!target.isSameClass(editedClass) && contains(editedClass)) {
             throw new DuplicateClassException();
         }
@@ -89,7 +90,9 @@ public class UniqueClassList implements Iterable<Classes> {
      */
     public void remove(Classes toRemove) {
         requireNonNull(toRemove);
-        internalList.remove(toRemove);
+        if (!internalList.remove(toRemove)) {
+            throw new CCNotFoundException();
+        }
         File f = new File(toRemove.getFilePath().toUri());
         f.delete();
     }

--- a/src/main/java/seedu/address/model/person/exceptions/CCNotFoundException.java
+++ b/src/main/java/seedu/address/model/person/exceptions/CCNotFoundException.java
@@ -1,0 +1,4 @@
+package seedu.address.model.person.exceptions;
+
+public class CCNotFoundException extends RuntimeException {
+}

--- a/src/test/java/seedu/address/logic/commands/DeleteCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/DeleteCommandTest.java
@@ -3,7 +3,7 @@ package seedu.address.logic.commands;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
-import static seedu.address.logic.commands.CommandTestUtil.assertCommandFailure;
+import static seedu.address.logic.commands.CommandTestUtil.*;
 import static seedu.address.testutil.TypicalIndexes.INDEX_FIRST_PERSON;
 import static seedu.address.testutil.TypicalIndexes.INDEX_SECOND_PERSON;
 import static seedu.address.testutil.TypicalPersons.getTypicalAddressBook;
@@ -16,9 +16,13 @@ import org.junit.jupiter.api.Test;
 import seedu.address.commons.core.index.Index;
 import seedu.address.commons.exceptions.DataLoadingException;
 import seedu.address.logic.Messages;
+import seedu.address.logic.commands.exceptions.CommandException;
 import seedu.address.model.Model;
 import seedu.address.model.ModelManager;
 import seedu.address.model.UserPrefs;
+import seedu.address.model.person.Classes;
+import seedu.address.model.person.CourseCode;
+import seedu.address.model.person.Person;
 
 /**
  * Contains integration tests (interaction with the Model) and unit tests for
@@ -55,7 +59,7 @@ public class DeleteCommandTest {
 
 
     @Test
-    public void execute_validIndexFilteredList_success() {
+    public void execute_validIndexFilteredList_success() throws DataLoadingException, IOException, CommandException {
         model.selectClass(new Classes(new CourseCode("class1")));
         showPersonAtIndex(model, INDEX_FIRST_PERSON);
         Person personToDelete = model.getFilteredPersonList().get(INDEX_FIRST_PERSON.getZeroBased());
@@ -73,7 +77,7 @@ public class DeleteCommandTest {
     }
 
     @Test
-    public void execute_invalidIndexFilteredList_throwsCommandException() {
+    public void execute_invalidIndexFilteredList_throwsCommandException() throws DataLoadingException, IOException {
         model.selectClass(new Classes(new CourseCode("class1")));
         showPersonAtIndex(model, INDEX_FIRST_PERSON);
 


### PR DESCRIPTION
Throws exception when trying to remove a class whose index does not exist.

Does not work for trying to select a class whose index does not exist.